### PR TITLE
Fix not unmarshal total count

### DIFF
--- a/esa_test.go
+++ b/esa_test.go
@@ -567,10 +567,10 @@ func TestGetTeams(t *testing.T) {
 	if teams.Teams[0].Url != "https://docs.esa.io/" {
 		t.Error("Url does not match")
 	}
-	if teams.PrevPage != "" {
+	if teams.PrevPage != 0 {
 		t.Error("PrevPage does not match")
 	}
-	if teams.NextPage != "1" {
+	if teams.NextPage != 1 {
 		t.Error("NextPage does not match")
 	}
 	if teams.TotalCount != 1 {
@@ -669,10 +669,10 @@ func TestGetMembers(t *testing.T) {
 	if members.Members[1].Email != "sano@example.com" {
 		t.Error("Email does not match")
 	}
-	if members.PrevPage != "" {
+	if members.PrevPage != 0 {
 		t.Error("PrevPage does not match")
 	}
-	if members.NextPage != "1" {
+	if members.NextPage != 1 {
 		t.Error("NextPage does not match")
 	}
 	if members.TotalCount != 2 {
@@ -753,10 +753,10 @@ func TestGetPosts(t *testing.T) {
 	if posts.Posts[0].UpdatedBy.Icon != "http://img.esa.io/uploads/production/users/1/icon/thumb_m_402685a258cf2a33c1d6c13a89adec92.png" {
 		t.Error("UpdatedBy.Icon does not match")
 	}
-	if posts.PrevPage != "" {
+	if posts.PrevPage != 0 {
 		t.Error("PrevPage does not match")
 	}
-	if posts.NextPage != "1" {
+	if posts.NextPage != 1 {
 		t.Error("NextPage does not match")
 	}
 	if posts.TotalCount != 1 {
@@ -1088,10 +1088,10 @@ func TestGetComments(t *testing.T) {
 	if comments.Comments[0].CreatedBy.Icon != "https://img.esa.io/uploads/production/users/1/icon/thumb_m_402685a258cf2a33c1d6c13a89adec92.png" {
 		t.Error("CreatedBy.Icon does not match")
 	}
-	if comments.PrevPage != "" {
+	if comments.PrevPage != 0 {
 		t.Error("PrevPage does not match")
 	}
-	if comments.NextPage != "1" {
+	if comments.NextPage != 1 {
 		t.Error("NextPage does not match")
 	}
 	if comments.TotalCount != 1 {

--- a/esa_test.go
+++ b/esa_test.go
@@ -3,11 +3,12 @@ package esa
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/hiroakis/esa-go/request"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/hiroakis/esa-go/request"
 )
 
 // All of the dummy data are from https://docs.esa.io/posts/102
@@ -25,7 +26,7 @@ var teamsHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request)
     }
   ],
   "prev_page": null,
-  "next_page": null,
+  "next_page": 1,
   "total_count": 1
 }
 `
@@ -99,7 +100,7 @@ var membersHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Reques
     }
   ],
   "prev_page": null,
-  "next_page": null,
+  "next_page": 1,
   "total_count": 2
 }
 `
@@ -147,7 +148,7 @@ var postsHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request)
     }
   ],
   "prev_page": null,
-  "next_page": null,
+  "next_page": 1,
   "total_count": 1
 }
 `
@@ -417,7 +418,7 @@ var commentsHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Reque
     }
   ],
   "prev_page": null,
-  "next_page": null,
+  "next_page": 1,
   "total_count": 1
 }
 `
@@ -569,7 +570,7 @@ func TestGetTeams(t *testing.T) {
 	if teams.PrevPage != "" {
 		t.Error("PrevPage does not match")
 	}
-	if teams.NextPage != "" {
+	if teams.NextPage != "1" {
 		t.Error("NextPage does not match")
 	}
 	if teams.TotalCount != 1 {
@@ -671,7 +672,7 @@ func TestGetMembers(t *testing.T) {
 	if members.PrevPage != "" {
 		t.Error("PrevPage does not match")
 	}
-	if members.NextPage != "" {
+	if members.NextPage != "1" {
 		t.Error("NextPage does not match")
 	}
 	if members.TotalCount != 2 {
@@ -755,7 +756,7 @@ func TestGetPosts(t *testing.T) {
 	if posts.PrevPage != "" {
 		t.Error("PrevPage does not match")
 	}
-	if posts.NextPage != "" {
+	if posts.NextPage != "1" {
 		t.Error("NextPage does not match")
 	}
 	if posts.TotalCount != 1 {
@@ -1090,7 +1091,7 @@ func TestGetComments(t *testing.T) {
 	if comments.PrevPage != "" {
 		t.Error("PrevPage does not match")
 	}
-	if comments.NextPage != "" {
+	if comments.NextPage != "1" {
 		t.Error("NextPage does not match")
 	}
 	if comments.TotalCount != 1 {

--- a/esa_test.go
+++ b/esa_test.go
@@ -567,10 +567,10 @@ func TestGetTeams(t *testing.T) {
 	if teams.Teams[0].Url != "https://docs.esa.io/" {
 		t.Error("Url does not match")
 	}
-	if teams.PrevPage != 0 {
+	if teams.PrevPage.String() != "" {
 		t.Error("PrevPage does not match")
 	}
-	if teams.NextPage != 1 {
+	if teams.NextPage.String() != "1" {
 		t.Error("NextPage does not match")
 	}
 	if teams.TotalCount != 1 {
@@ -669,10 +669,10 @@ func TestGetMembers(t *testing.T) {
 	if members.Members[1].Email != "sano@example.com" {
 		t.Error("Email does not match")
 	}
-	if members.PrevPage != 0 {
+	if members.PrevPage.String() != "" {
 		t.Error("PrevPage does not match")
 	}
-	if members.NextPage != 1 {
+	if members.NextPage.String() != "1" {
 		t.Error("NextPage does not match")
 	}
 	if members.TotalCount != 2 {
@@ -753,10 +753,10 @@ func TestGetPosts(t *testing.T) {
 	if posts.Posts[0].UpdatedBy.Icon != "http://img.esa.io/uploads/production/users/1/icon/thumb_m_402685a258cf2a33c1d6c13a89adec92.png" {
 		t.Error("UpdatedBy.Icon does not match")
 	}
-	if posts.PrevPage != 0 {
+	if posts.PrevPage.String() != "" {
 		t.Error("PrevPage does not match")
 	}
-	if posts.NextPage != 1 {
+	if posts.NextPage.String() != "1" {
 		t.Error("NextPage does not match")
 	}
 	if posts.TotalCount != 1 {
@@ -1088,10 +1088,10 @@ func TestGetComments(t *testing.T) {
 	if comments.Comments[0].CreatedBy.Icon != "https://img.esa.io/uploads/production/users/1/icon/thumb_m_402685a258cf2a33c1d6c13a89adec92.png" {
 		t.Error("CreatedBy.Icon does not match")
 	}
-	if comments.PrevPage != 0 {
+	if comments.PrevPage.String() != "" {
 		t.Error("PrevPage does not match")
 	}
-	if comments.NextPage != 1 {
+	if comments.NextPage.String() != "1" {
 		t.Error("NextPage does not match")
 	}
 	if comments.TotalCount != 1 {

--- a/response/response.go
+++ b/response/response.go
@@ -14,8 +14,8 @@ type Team struct {
 
 type Teams struct {
 	Teams      []Team `json:"teams"`
-	PrevPage   string `json:"prev_page"`
-	NextPage   string `json:"next_page"`
+	PrevPage   int    `json:"prev_page"`
+	NextPage   int    `json:"next_page"`
 	TotalCount int    `json:"total_count"`
 }
 
@@ -38,8 +38,8 @@ type Member struct {
 
 type Members struct {
 	Members    []Member `json:"members"`
-	PrevPage   string   `json:"prev_page"`
-	NextPage   string   `json:"next_page"`
+	PrevPage   int      `json:"prev_page"`
+	NextPage   int      `json:"next_page"`
 	TotalCount int      `json:"total_count"`
 }
 
@@ -51,8 +51,8 @@ type ByUser struct {
 
 type Posts struct {
 	Posts      []Post `json:"posts"`
-	PrevPage   string `json:"prev_page"`
-	NextPage   string `json:"next_page"`
+	PrevPage   int    `json:"prev_page"`
+	NextPage   int    `json:"next_page"`
 	TotalCount int    `json:"total_count"`
 }
 
@@ -95,7 +95,7 @@ type Comment struct {
 
 type Comments struct {
 	Comments   []Comment `json:"comments"`
-	PrevPage   string    `json:"prev_page"`
-	NextPage   string    `json:"next_page"`
+	PrevPage   int       `json:"prev_page"`
+	NextPage   int       `json:"next_page"`
 	TotalCount int       `json:"total_count"`
 }

--- a/response/response.go
+++ b/response/response.go
@@ -1,6 +1,7 @@
 package response
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -13,10 +14,10 @@ type Team struct {
 }
 
 type Teams struct {
-	Teams      []Team `json:"teams"`
-	PrevPage   int    `json:"prev_page"`
-	NextPage   int    `json:"next_page"`
-	TotalCount int    `json:"total_count"`
+	Teams      []Team      `json:"teams"`
+	PrevPage   json.Number `json:"prev_page"`
+	NextPage   json.Number `json:"next_page"`
+	TotalCount int         `json:"total_count"`
 }
 
 type Stats struct {
@@ -37,10 +38,10 @@ type Member struct {
 }
 
 type Members struct {
-	Members    []Member `json:"members"`
-	PrevPage   int      `json:"prev_page"`
-	NextPage   int      `json:"next_page"`
-	TotalCount int      `json:"total_count"`
+	Members    []Member    `json:"members"`
+	PrevPage   json.Number `json:"prev_page"`
+	NextPage   json.Number `json:"next_page"`
+	TotalCount int         `json:"total_count"`
 }
 
 type ByUser struct {
@@ -50,10 +51,10 @@ type ByUser struct {
 }
 
 type Posts struct {
-	Posts      []Post `json:"posts"`
-	PrevPage   int    `json:"prev_page"`
-	NextPage   int    `json:"next_page"`
-	TotalCount int    `json:"total_count"`
+	Posts      []Post      `json:"posts"`
+	PrevPage   json.Number `json:"prev_page"`
+	NextPage   json.Number `json:"next_page"`
+	TotalCount int         `json:"total_count"`
 }
 
 type Post struct {
@@ -94,8 +95,8 @@ type Comment struct {
 }
 
 type Comments struct {
-	Comments   []Comment `json:"comments"`
-	PrevPage   int       `json:"prev_page"`
-	NextPage   int       `json:"next_page"`
-	TotalCount int       `json:"total_count"`
+	Comments   []Comment   `json:"comments"`
+	PrevPage   json.Number `json:"prev_page"`
+	NextPage   json.Number `json:"next_page"`
+	TotalCount int         `json:"total_count"`
 }


### PR DESCRIPTION
It seems to me to NOT unmarshal `response.Posts.TotalCount`.

The cause of it is `PrevPage, NextPage` is not string type in JSON.

https://docs.esa.io/posts/102#%E3%83%9A%E3%83%BC%E3%82%B8%E3%83%8D%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3

This PR change `PrevPage, NextPage` type string to int.

```sh
$ curl -sG "https://api.esa.io/v1/teams/<TEAM>/posts?access_token=<TOKEN>&" |jq ".prev_page, .next_page, .total_count"
null
2
1261
```

```go
package main

import (
    "fmt"
    "log"

    "github.com/hiroakis/esa-go"
)

func main() {
    apiToken := "<TOKEN>"
    teamName := "<TEAM>"

    client := esa.NewEsaClient(apiToken, teamName)

    posts, err := client.GetPosts()
    if err != nil {
        log.Fatal(err)
    }

    fmt.Println(posts.PrevPage, posts.NextPage, posts.TotalCount)
}
```

```sh
$ go run main.go
  0
```
