### PR TITLE
Support template_post_id when create posts

### DIFF
--- a/esa_test.go
+++ b/esa_test.go
@@ -878,6 +878,7 @@ func TestCreatePost(t *testing.T) {
 			Category: "dev/2015/05/10",
 			Wip:      false,
 			Message:  "Add Getting Started section",
+			TemplatePostId: 123,
 		}
 	post, err := fakeClient(testServer.URL).CreatePost(reqPost)
 

--- a/request/request.go
+++ b/request/request.go
@@ -12,6 +12,7 @@ type Post struct {
 	Wip              bool             `json:"wip"`
 	Message          string           `json:"message"`
 	OriginalRevision OriginalRevision `json:"original_revision,omitempty"`
+	TemplatePostId   int              `json:"template_post_id"`
 }
 
 type OriginalRevision struct {


### PR DESCRIPTION
Support template_post_id when create posts.

https://docs.esa.io/posts/102#POST%20/v1/teams/:team_name/posts