### PR TITLE
Support template_post_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ func main() {
     }
     fmt.Println(createdPost)
 
+    // create new post use template
+    reqPost :=
+        request.Post{
+            TemplatePostId: 123,
+        }
+
+    createdPost, err := c.CreatePost(reqPost)
+    if err != nil {
+        fmt.Println(err)
+    }
+    fmt.Println(createdPost)
+
     // update post
     reqPost :=
         request.Post{

--- a/request/request.go
+++ b/request/request.go
@@ -5,13 +5,14 @@ type PostData struct {
 }
 
 type Post struct {
-	Name             string           `json:"name"`
-	BodyMd           string           `json:"body_md"`
+	Name             string           `json:"name,omitempty"`
+	BodyMd           string           `json:"body_md,omitempty"`
 	Tags             []string         `json:"tags"`
 	Category         string           `json:"category"`
 	Wip              bool             `json:"wip"`
 	Message          string           `json:"message"`
 	OriginalRevision OriginalRevision `json:"original_revision,omitempty"`
+	TemplatePostId   int              `json:"template_post_id"`
 }
 
 type OriginalRevision struct {

--- a/request/request.go
+++ b/request/request.go
@@ -8,7 +8,7 @@ type Post struct {
 	Name             string           `json:"name,omitempty"`
 	BodyMd           string           `json:"body_md,omitempty"`
 	Tags             []string         `json:"tags"`
-	Category         string           `json:"category"`
+	Category         string           `json:"category,omitempty"`
 	Wip              bool             `json:"wip"`
 	Message          string           `json:"message"`
 	OriginalRevision OriginalRevision `json:"original_revision,omitempty"`


### PR DESCRIPTION
Support template_post_id. (https://docs.esa.io/posts/102#POST%20/v1/teams/:team_name/posts)

- When post `name=""`, API returns 400 Bad Request
- When post `body_md=""`, New post is overwrited empty string.
